### PR TITLE
Fixed TypeError when OLX API returns HTTP 204 No Content

### DIFF
--- a/tests/AdvertsTest.php
+++ b/tests/AdvertsTest.php
@@ -69,11 +69,11 @@ class AdvertsTest extends TestCase
         $this->client->expects($this->once())
             ->method('request')
             ->with('DELETE', 'partner/adverts/1')
-            ->willReturn(['id' => 1, 'title' => 'Advert 1']);
+            ->willReturn([]);
 
         $response = $this->client->adverts()->delete(1);
 
-        $this->assertEquals(['id' => 1, 'title' => 'Advert 1'], $response);
+        $this->assertEquals([], $response);
     }
 
     public function testActivate()
@@ -81,11 +81,11 @@ class AdvertsTest extends TestCase
         $this->client->expects($this->once())
             ->method('request')
             ->with('POST', 'partner/adverts/1/commands', ['command' => 'activate'])
-            ->willReturn(['id' => 1, 'title' => 'Advert 1']);
+            ->willReturn([]);
 
         $response = $this->client->adverts()->activate(1);
 
-        $this->assertEquals(['id' => 1, 'title' => 'Advert 1'], $response);
+        $this->assertEquals([], $response);
     }
 
     public function testDeactivate()
@@ -93,10 +93,10 @@ class AdvertsTest extends TestCase
         $this->client->expects($this->once())
             ->method('request')
             ->with('POST', 'partner/adverts/1/commands', ['command' => 'deactivate', 'is_success' => true])
-            ->willReturn(['id' => 1, 'title' => 'Advert 1']);
+            ->willReturn([]);
 
         $response = $this->client->adverts()->deactivate(1, true);
 
-        $this->assertEquals(['id' => 1, 'title' => 'Advert 1'], $response);
+        $this->assertEquals([], $response);
     }
 }

--- a/tests/ThreadsTest.php
+++ b/tests/ThreadsTest.php
@@ -69,11 +69,11 @@ class ThreadsTest extends TestCase
         $this->client->expects($this->once())
             ->method('request')
             ->with('POST', 'partner/threads/1/commands', ['command' => 'mark-as-read'])
-            ->willReturn(['status' => 'success']);
+            ->willReturn([]);
 
         $response = $this->client->threads()->markAsRead(1);
 
-        $this->assertEquals(['status' => 'success'], $response);
+        $this->assertEquals([], $response);
     }
 
     public function testSetFavorite()
@@ -81,10 +81,10 @@ class ThreadsTest extends TestCase
         $this->client->expects($this->once())
             ->method('request')
             ->with('POST', 'partner/threads/1/commands', ['command' => 'set-favourite', 'is_favourite' => true])
-            ->willReturn(['status' => 'success']);
+            ->willReturn([]);
 
         $response = $this->client->threads()->setFavorite(1, true);
 
-        $this->assertEquals(['status' => 'success'], $response);
+        $this->assertEquals([], $response);
     }
 }

--- a/tests/UsersBusinessTest.php
+++ b/tests/UsersBusinessTest.php
@@ -83,11 +83,11 @@ class UsersBusinessTest extends TestCase
         $this->client->expects($this->once())
             ->method('request')
             ->with('DELETE', 'partner/users-business/me/logos/1')
-            ->willReturn(['status' => 'success']);
+            ->willReturn([]);
 
         $response = $this->client->usersBusiness()->deleteLogo(1);
 
-        $this->assertEquals(['status' => 'success'], $response);
+        $this->assertEquals([], $response);
     }
 
     public function testGetBanners()
@@ -119,10 +119,10 @@ class UsersBusinessTest extends TestCase
         $this->client->expects($this->once())
             ->method('request')
             ->with('DELETE', 'partner/users-business/me/banners/1')
-            ->willReturn(['status' => 'success']);
+            ->willReturn([]);
 
         $response = $this->client->usersBusiness()->deleteBanner(1);
 
-        $this->assertEquals(['status' => 'success'], $response);
+        $this->assertEquals([], $response);
     }
 }


### PR DESCRIPTION
- Modified handleResponse() in Client.php to use null coalescing operator, returning an empty array when JSON decode returns null
- Updated test expectations for DELETE and command operations to expect empty arrays